### PR TITLE
Pick up new Android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.getpinwheel.pinwheel'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         jcenter()
@@ -18,7 +18,7 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
+        mavenCentral()
     }
 }
 
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.underdog-tech:pinwheel-android-sdk:2.3.2'
+    implementation 'com.getpinwheel:pinwheel-android:2.3.11'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.4.30"
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Description of the change

This will bring the Flutter SDK to parity with the Android SDK (2.3.11).
https://github.com/underdog-tech/pinwheel-android-sdk/releases

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Problem with minifying on Android #5 
