### PR TITLE
Release 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3
+Added proguard R8 rule to protect Android Plugin classes from being removed.
+
 ## 0.0.2
 Update iOS dependency to [2.3.6](https://github.com/underdog-tech/pinwheel-ios-sdk/releases)
 Update Android dependency to [2.3.11](https://github.com/underdog-tech/pinwheel-android-sdk/releases)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -136,7 +136,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pinwheel
 description: A flutter plugin for the Pinwheel Link SDK.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/underdog-tech/pinwheel-flutter-sdk
 documentation: https://github.com/underdog-tech/pinwheel-flutter-sdk
 


### PR DESCRIPTION
## Description of the change

Added proguard R8 rule to protect Android Plugin classes from being removed. #9 


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Problem with minifying on Android #5
