### PR TITLE
Upgrade to pull in latest Android and iOS SDK dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.getpinwheel:pinwheel-android:3.0.2-alpha.2'
+    implementation 'com.getpinwheel:pinwheel-android:3.4.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.4.30"
 }

--- a/android/src/main/kotlin/com/getpinwheel/pinwheel/PinwheelPlugin.kt
+++ b/android/src/main/kotlin/com/getpinwheel/pinwheel/PinwheelPlugin.kt
@@ -178,6 +178,7 @@ internal class NativeView(context: Context, messenger: BinaryMessenger, id: Int,
   private var pinwheelView: PinwheelFrameLayout
   private var textView: TextView
   private var token: String?
+  private var useDarkMode: Boolean?
 
   override fun getView(): View {
     val result = pinwheelView
@@ -200,7 +201,9 @@ internal class NativeView(context: Context, messenger: BinaryMessenger, id: Int,
       token = ""
     }
 
-    pinwheelView = PinwheelViewGroupManager.init(context, readLinkToken(), pinwheelEventListener, "flutter", "3.0.0")
+    useDarkMode = creationParams?.optBoolean("useDarkMode", false) ?: false
+
+    pinwheelView = PinwheelViewGroupManager.init(context, readLinkToken(), pinwheelEventListener, "flutter", "3.0.0", useDarkMode=useDarkMode ?: false)
 
     textView = TextView(context)
     textView.textSize = 36f

--- a/android/src/main/kotlin/com/getpinwheel/pinwheel/PinwheelPlugin.kt
+++ b/android/src/main/kotlin/com/getpinwheel/pinwheel/PinwheelPlugin.kt
@@ -154,6 +154,10 @@ class PluginListener(messenger: BinaryMessenger) : PinwheelEventListener {
         val obj = PinwheelEventChannelArgument("screen_transition", gson.toJson(payload))
         argument = gson.toJson(obj)
       }
+      PinwheelEventType.OTHER_EVENT -> {
+        val obj = PinwheelEventChannelArgument("other_event", gson.toJson(payload))
+        argument = gson.toJson(obj)
+      }
     }
 
     Handler(Looper.getMainLooper()).post {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Flutter (1.0.0)
   - pinwheel (0.0.3):
     - Flutter
-    - PinwheelSDK (= 3.0.2)
-  - PinwheelSDK (3.0.2):
-    - PinwheelSDK/PinwheelLinkSDK (= 3.0.2)
-  - PinwheelSDK/PinwheelLinkSDK (3.0.2)
+    - PinwheelSDK (= 3.3.2)
+  - PinwheelSDK (3.3.2):
+    - PinwheelSDK/PinwheelLinkSDK (= 3.3.2)
+  - PinwheelSDK/PinwheelLinkSDK (3.3.2)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -23,8 +23,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  pinwheel: 753a112e9f545e0cb848a2d1b1c04668c05122f2
-  PinwheelSDK: 39a8fdce5f550956e402d10e93ff40612a65d85e
+  pinwheel: 0f180a29d782d20723d3ce6ac9c2f09460344114
+  PinwheelSDK: 95c09f96b7b4ed8571a97feb0eb111e7923ab556
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
 

--- a/ios/Classes/SwiftPinwheelPlugin.swift
+++ b/ios/Classes/SwiftPinwheelPlugin.swift
@@ -53,6 +53,7 @@ class FLNativeViewFactory: NSObject, FlutterPlatformViewFactory {
 class FLNativeView: NSObject, FlutterPlatformView {
     private var _view: UIView
     private var _token: String?
+    private var _useDarkMode: Bool?
     private var _pinwheelVC: PinwheelViewController?
     private var _channel: FlutterMethodChannel?
 
@@ -75,6 +76,11 @@ class FLNativeView: NSObject, FlutterPlatformView {
         {
             _token = token
         }
+        if let dict = args as? NSDictionary,
+            let useDarkMode = dict["useDarkMode"] as? Bool
+        {
+            _useDarkMode = useDarkMode
+        }
         createNativeView(view: _view)
     }
 
@@ -91,7 +97,9 @@ class FLNativeView: NSObject, FlutterPlatformView {
         }
         let config = PinwheelConfig(
             mode: .sandbox, environment: .production, sdk: "flutter", version: "3.0.0")
-        _pinwheelVC = PinwheelViewController(token: token, delegate: self, config: config)
+        let useDarkMode = _useDarkMode ?? false
+        _pinwheelVC = PinwheelViewController(
+            token: token, delegate: self, config: config, useDarkMode: useDarkMode)
         if let view = _pinwheelVC?.view {
             view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             _view.addSubview(view)

--- a/ios/pinwheel.podspec
+++ b/ios/pinwheel.podspec
@@ -21,5 +21,5 @@ A new flutter plugin project.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
   
-  s.dependency 'PinwheelSDK', '3.0.2'
+  s.dependency 'PinwheelSDK', '3.3.2'
 end

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,34 +1,50 @@
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
+import 'package:built_collection/built_collection.dart';
 
 part 'models.g.dart';
 
 @BuiltValue(instantiable: false)
 abstract class PinwheelEventPayload extends Object {
-
-  PinwheelEventPayload rebuild(void Function(PinwheelEventPayloadBuilder) updates);
+  PinwheelEventPayload rebuild(
+      void Function(PinwheelEventPayloadBuilder) updates);
   PinwheelEventPayloadBuilder toBuilder();
 }
 
-abstract class PinwheelAllocation implements PinwheelEventPayload, Built<PinwheelAllocation, PinwheelAllocationBuilder> {
+abstract class PinwheelAllocation
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelAllocation, PinwheelAllocationBuilder> {
   String get type;
   double? get value;
 
   PinwheelAllocation._();
-  factory PinwheelAllocation([updates(PinwheelAllocationBuilder b)]) = _$PinwheelAllocation;
-  static Serializer<PinwheelAllocation> get serializer => _$pinwheelAllocationSerializer;
+  factory PinwheelAllocation([updates(PinwheelAllocationBuilder b)]) =
+      _$PinwheelAllocation;
+  static Serializer<PinwheelAllocation> get serializer =>
+      _$pinwheelAllocationSerializer;
 }
 
-abstract class PinwheelInputAllocationPayload implements PinwheelEventPayload, Built<PinwheelInputAllocationPayload, PinwheelInputAllocationPayloadBuilder> {
+abstract class PinwheelInputAllocationPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelInputAllocationPayload,
+            PinwheelInputAllocationPayloadBuilder> {
   String? get action;
   PinwheelAllocation? get allocation;
 
   PinwheelInputAllocationPayload._();
-  factory PinwheelInputAllocationPayload([updates(PinwheelInputAllocationPayloadBuilder b)]) = _$PinwheelInputAllocationPayload;
-  static Serializer<PinwheelInputAllocationPayload> get serializer => _$pinwheelInputAllocationPayloadSerializer;
+  factory PinwheelInputAllocationPayload(
+          [updates(PinwheelInputAllocationPayloadBuilder b)]) =
+      _$PinwheelInputAllocationPayload;
+  static Serializer<PinwheelInputAllocationPayload> get serializer =>
+      _$pinwheelInputAllocationPayloadSerializer;
 }
 
-abstract class PinwheelError implements PinwheelEventPayload, Built<PinwheelError, PinwheelErrorBuilder> {
+abstract class PinwheelError
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelError, PinwheelErrorBuilder> {
   String get type;
   String get code;
   String get message;
@@ -39,65 +55,102 @@ abstract class PinwheelError implements PinwheelEventPayload, Built<PinwheelErro
   static Serializer<PinwheelError> get serializer => _$pinwheelErrorSerializer;
 }
 
-abstract class PinwheelExitPayload implements PinwheelEventPayload, Built<PinwheelExitPayload, PinwheelExitPayloadBuilder> {
+abstract class PinwheelExitPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelExitPayload, PinwheelExitPayloadBuilder> {
   PinwheelError? get error;
 
   PinwheelExitPayload._();
 
-  factory PinwheelExitPayload([updates(PinwheelExitPayloadBuilder b)]) = _$PinwheelExitPayload;
-  static Serializer<PinwheelExitPayload> get serializer => _$pinwheelExitPayloadSerializer;
+  factory PinwheelExitPayload([updates(PinwheelExitPayloadBuilder b)]) =
+      _$PinwheelExitPayload;
+  static Serializer<PinwheelExitPayload> get serializer =>
+      _$pinwheelExitPayloadSerializer;
 }
 
-abstract class PinwheelLoginPayload implements PinwheelEventPayload, Built<PinwheelLoginPayload, PinwheelLoginPayloadBuilder> {
+abstract class PinwheelLoginPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelLoginPayload, PinwheelLoginPayloadBuilder> {
   String get accountId;
   String? get platformId;
 
   PinwheelLoginPayload._();
 
-  factory PinwheelLoginPayload([updates(PinwheelLoginPayloadBuilder b)]) = _$PinwheelLoginPayload;
-  static Serializer<PinwheelLoginPayload> get serializer => _$pinwheelLoginPayloadSerializer;
+  factory PinwheelLoginPayload([updates(PinwheelLoginPayloadBuilder b)]) =
+      _$PinwheelLoginPayload;
+  static Serializer<PinwheelLoginPayload> get serializer =>
+      _$pinwheelLoginPayloadSerializer;
 }
 
-abstract class PinwheelLoginAttemptPayload implements PinwheelEventPayload, Built<PinwheelLoginAttemptPayload, PinwheelLoginAttemptPayloadBuilder> {
+abstract class PinwheelLoginAttemptPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelLoginAttemptPayload, PinwheelLoginAttemptPayloadBuilder> {
   String get platformId;
 
   PinwheelLoginAttemptPayload._();
 
-  factory PinwheelLoginAttemptPayload([updates(PinwheelLoginAttemptPayloadBuilder b)]) = _$PinwheelLoginAttemptPayload;
-  static Serializer<PinwheelLoginAttemptPayload> get serializer => _$pinwheelLoginAttemptPayloadSerializer;
+  factory PinwheelLoginAttemptPayload(
+          [updates(PinwheelLoginAttemptPayloadBuilder b)]) =
+      _$PinwheelLoginAttemptPayload;
+  static Serializer<PinwheelLoginAttemptPayload> get serializer =>
+      _$pinwheelLoginAttemptPayloadSerializer;
 }
 
-abstract class PinwheelParams implements PinwheelEventPayload, Built<PinwheelParams, PinwheelParamsBuilder> {
+abstract class PinwheelParams
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelParams, PinwheelParamsBuilder> {
   String? get action;
   PinwheelAllocation? get allocation;
 
   PinwheelParams._();
 
   factory PinwheelParams([updates(PinwheelParamsBuilder b)]) = _$PinwheelParams;
-  static Serializer<PinwheelParams> get serializer => _$pinwheelParamsSerializer;
+  static Serializer<PinwheelParams> get serializer =>
+      _$pinwheelParamsSerializer;
 }
 
-abstract class PinwheelSelectedEmployerPayload implements PinwheelEventPayload, Built<PinwheelSelectedEmployerPayload, PinwheelSelectedEmployerPayloadBuilder> {
+abstract class PinwheelSelectedEmployerPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelSelectedEmployerPayload,
+            PinwheelSelectedEmployerPayloadBuilder> {
   String get selectedEmployerId;
   String get selectedEmployerName;
 
   PinwheelSelectedEmployerPayload._();
 
-  factory PinwheelSelectedEmployerPayload([updates(PinwheelSelectedEmployerPayloadBuilder b)]) = _$PinwheelSelectedEmployerPayload;
-  static Serializer<PinwheelSelectedEmployerPayload> get serializer => _$pinwheelSelectedEmployerPayloadSerializer;
+  factory PinwheelSelectedEmployerPayload(
+          [updates(PinwheelSelectedEmployerPayloadBuilder b)]) =
+      _$PinwheelSelectedEmployerPayload;
+  static Serializer<PinwheelSelectedEmployerPayload> get serializer =>
+      _$pinwheelSelectedEmployerPayloadSerializer;
 }
 
-abstract class PinwheelSelectedPlatformPayload implements PinwheelEventPayload, Built<PinwheelSelectedPlatformPayload, PinwheelSelectedPlatformPayloadBuilder> {
+abstract class PinwheelSelectedPlatformPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelSelectedPlatformPayload,
+            PinwheelSelectedPlatformPayloadBuilder> {
   String get selectedPlatformId;
   String get selectedPlatformName;
 
   PinwheelSelectedPlatformPayload._();
 
-  factory PinwheelSelectedPlatformPayload([updates(PinwheelSelectedPlatformPayloadBuilder b)]) = _$PinwheelSelectedPlatformPayload;
-  static Serializer<PinwheelSelectedPlatformPayload> get serializer => _$pinwheelSelectedPlatformPayloadSerializer;
+  factory PinwheelSelectedPlatformPayload(
+          [updates(PinwheelSelectedPlatformPayloadBuilder b)]) =
+      _$PinwheelSelectedPlatformPayload;
+  static Serializer<PinwheelSelectedPlatformPayload> get serializer =>
+      _$pinwheelSelectedPlatformPayloadSerializer;
 }
 
-abstract class PinwheelSuccessPayload implements PinwheelEventPayload, Built<PinwheelSuccessPayload, PinwheelSuccessPayloadBuilder> {
+abstract class PinwheelSuccessPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelSuccessPayload, PinwheelSuccessPayloadBuilder> {
   String get accountId;
   String get platformId;
   String get job;
@@ -105,30 +158,48 @@ abstract class PinwheelSuccessPayload implements PinwheelEventPayload, Built<Pin
 
   PinwheelSuccessPayload._();
 
-  factory PinwheelSuccessPayload([updates(PinwheelSuccessPayloadBuilder b)]) = _$PinwheelSuccessPayload;
-  static Serializer<PinwheelSuccessPayload> get serializer => _$pinwheelSuccessPayloadSerializer;
+  factory PinwheelSuccessPayload([updates(PinwheelSuccessPayloadBuilder b)]) =
+      _$PinwheelSuccessPayload;
+  static Serializer<PinwheelSuccessPayload> get serializer =>
+      _$pinwheelSuccessPayloadSerializer;
 }
 
-abstract class PinwheelEventChannelArgument implements Built<PinwheelEventChannelArgument, PinwheelEventChannelArgumentBuilder> {
+abstract class PinwheelEventChannelArgument
+    implements
+        Built<PinwheelEventChannelArgument,
+            PinwheelEventChannelArgumentBuilder> {
   String get name;
   String? get payload;
 
   PinwheelEventChannelArgument._();
 
-  factory PinwheelEventChannelArgument([updates(PinwheelEventChannelArgumentBuilder b)]) = _$PinwheelEventChannelArgument;
-  static Serializer<PinwheelEventChannelArgument> get serializer => _$pinwheelEventChannelArgumentSerializer;
+  factory PinwheelEventChannelArgument(
+          [updates(PinwheelEventChannelArgumentBuilder b)]) =
+      _$PinwheelEventChannelArgument;
+  static Serializer<PinwheelEventChannelArgument> get serializer =>
+      _$pinwheelEventChannelArgumentSerializer;
 }
 
-abstract class PinwheelDDFormCreatePayload implements PinwheelEventPayload, Built<PinwheelDDFormCreatePayload, PinwheelDDFormCreatePayloadBuilder> {
+abstract class PinwheelDDFormCreatePayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelDDFormCreatePayload, PinwheelDDFormCreatePayloadBuilder> {
   String get url;
 
   PinwheelDDFormCreatePayload._();
 
-  factory PinwheelDDFormCreatePayload([updates(PinwheelDDFormCreatePayloadBuilder b)]) = _$PinwheelDDFormCreatePayload;
-  static Serializer<PinwheelDDFormCreatePayload> get serializer => _$pinwheelDDFormCreatePayloadSerializer;
+  factory PinwheelDDFormCreatePayload(
+          [updates(PinwheelDDFormCreatePayloadBuilder b)]) =
+      _$PinwheelDDFormCreatePayload;
+  static Serializer<PinwheelDDFormCreatePayload> get serializer =>
+      _$pinwheelDDFormCreatePayloadSerializer;
 }
 
-abstract class PinwheelScreenTransitionPayload implements PinwheelEventPayload, Built<PinwheelScreenTransitionPayload, PinwheelScreenTransitionPayloadBuilder> {
+abstract class PinwheelScreenTransitionPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelScreenTransitionPayload,
+            PinwheelScreenTransitionPayloadBuilder> {
   String get screenName;
   String? get selectedEmployerId;
   String? get selectedEmployerName;
@@ -137,6 +208,64 @@ abstract class PinwheelScreenTransitionPayload implements PinwheelEventPayload, 
 
   PinwheelScreenTransitionPayload._();
 
-  factory PinwheelScreenTransitionPayload([updates(PinwheelScreenTransitionPayloadBuilder b)]) = _$PinwheelScreenTransitionPayload;
-  static Serializer<PinwheelScreenTransitionPayload> get serializer => _$pinwheelScreenTransitionPayloadSerializer;
+  factory PinwheelScreenTransitionPayload(
+          [updates(PinwheelScreenTransitionPayloadBuilder b)]) =
+      _$PinwheelScreenTransitionPayload;
+  static Serializer<PinwheelScreenTransitionPayload> get serializer =>
+      _$pinwheelScreenTransitionPayloadSerializer;
+}
+
+class PinwheelOtherEventPayloadValueType extends EnumClass {
+  @BuiltValueEnumConst(wireName: 'string')
+  static const PinwheelOtherEventPayloadValueType STRING = _$string;
+
+  @BuiltValueEnumConst(wireName: 'number')
+  static const PinwheelOtherEventPayloadValueType NUMBER = _$number;
+
+  @BuiltValueEnumConst(wireName: 'boolean')
+  static const PinwheelOtherEventPayloadValueType BOOLEAN = _$boolean;
+
+  const PinwheelOtherEventPayloadValueType._(String name) : super(name);
+
+  static BuiltSet<PinwheelOtherEventPayloadValueType> get values =>
+      _$pinwheelOtherEventPayloadValueTypeValues;
+  static PinwheelOtherEventPayloadValueType valueOf(String name) =>
+      _$pinwheelOtherEventPayloadValueTypeValueOf(name);
+
+  static Serializer<PinwheelOtherEventPayloadValueType> get serializer =>
+      _$pinwheelOtherEventPayloadValueTypeSerializer;
+}
+
+abstract class PinwheelOtherEventPayloadItem
+    implements
+        Built<PinwheelOtherEventPayloadItem,
+            PinwheelOtherEventPayloadItemBuilder> {
+  String get key;
+  String get value;
+
+  PinwheelOtherEventPayloadValueType get type;
+
+  PinwheelOtherEventPayloadItem._();
+  factory PinwheelOtherEventPayloadItem(
+          [void Function(PinwheelOtherEventPayloadItemBuilder) updates]) =
+      _$PinwheelOtherEventPayloadItem;
+
+  static Serializer<PinwheelOtherEventPayloadItem> get serializer =>
+      _$pinwheelOtherEventPayloadItemSerializer;
+}
+
+abstract class PinwheelOtherEventPayload
+    implements
+        PinwheelEventPayload,
+        Built<PinwheelOtherEventPayload, PinwheelOtherEventPayloadBuilder> {
+  String get name;
+  BuiltList<PinwheelOtherEventPayloadItem> get payload;
+
+  PinwheelOtherEventPayload._();
+  factory PinwheelOtherEventPayload(
+          [void Function(PinwheelOtherEventPayloadBuilder) updates]) =
+      _$PinwheelOtherEventPayload;
+
+  static Serializer<PinwheelOtherEventPayload> get serializer =>
+      _$pinwheelOtherEventPayloadSerializer;
 }

--- a/lib/models.g.dart
+++ b/lib/models.g.dart
@@ -6,39 +6,76 @@ part of 'models.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const PinwheelOtherEventPayloadValueType _$string =
+    const PinwheelOtherEventPayloadValueType._('STRING');
+const PinwheelOtherEventPayloadValueType _$number =
+    const PinwheelOtherEventPayloadValueType._('NUMBER');
+const PinwheelOtherEventPayloadValueType _$boolean =
+    const PinwheelOtherEventPayloadValueType._('BOOLEAN');
+
+PinwheelOtherEventPayloadValueType _$pinwheelOtherEventPayloadValueTypeValueOf(
+    String name) {
+  switch (name) {
+    case 'STRING':
+      return _$string;
+    case 'NUMBER':
+      return _$number;
+    case 'BOOLEAN':
+      return _$boolean;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PinwheelOtherEventPayloadValueType>
+    _$pinwheelOtherEventPayloadValueTypeValues = BuiltSet<
+        PinwheelOtherEventPayloadValueType>(const <PinwheelOtherEventPayloadValueType>[
+  _$string,
+  _$number,
+  _$boolean,
+]);
+
 Serializer<PinwheelAllocation> _$pinwheelAllocationSerializer =
-    new _$PinwheelAllocationSerializer();
+    _$PinwheelAllocationSerializer();
 Serializer<PinwheelInputAllocationPayload>
     _$pinwheelInputAllocationPayloadSerializer =
-    new _$PinwheelInputAllocationPayloadSerializer();
+    _$PinwheelInputAllocationPayloadSerializer();
 Serializer<PinwheelError> _$pinwheelErrorSerializer =
-    new _$PinwheelErrorSerializer();
+    _$PinwheelErrorSerializer();
 Serializer<PinwheelExitPayload> _$pinwheelExitPayloadSerializer =
-    new _$PinwheelExitPayloadSerializer();
+    _$PinwheelExitPayloadSerializer();
 Serializer<PinwheelLoginPayload> _$pinwheelLoginPayloadSerializer =
-    new _$PinwheelLoginPayloadSerializer();
+    _$PinwheelLoginPayloadSerializer();
 Serializer<PinwheelLoginAttemptPayload>
     _$pinwheelLoginAttemptPayloadSerializer =
-    new _$PinwheelLoginAttemptPayloadSerializer();
+    _$PinwheelLoginAttemptPayloadSerializer();
 Serializer<PinwheelParams> _$pinwheelParamsSerializer =
-    new _$PinwheelParamsSerializer();
+    _$PinwheelParamsSerializer();
 Serializer<PinwheelSelectedEmployerPayload>
     _$pinwheelSelectedEmployerPayloadSerializer =
-    new _$PinwheelSelectedEmployerPayloadSerializer();
+    _$PinwheelSelectedEmployerPayloadSerializer();
 Serializer<PinwheelSelectedPlatformPayload>
     _$pinwheelSelectedPlatformPayloadSerializer =
-    new _$PinwheelSelectedPlatformPayloadSerializer();
+    _$PinwheelSelectedPlatformPayloadSerializer();
 Serializer<PinwheelSuccessPayload> _$pinwheelSuccessPayloadSerializer =
-    new _$PinwheelSuccessPayloadSerializer();
+    _$PinwheelSuccessPayloadSerializer();
 Serializer<PinwheelEventChannelArgument>
     _$pinwheelEventChannelArgumentSerializer =
-    new _$PinwheelEventChannelArgumentSerializer();
+    _$PinwheelEventChannelArgumentSerializer();
 Serializer<PinwheelDDFormCreatePayload>
     _$pinwheelDDFormCreatePayloadSerializer =
-    new _$PinwheelDDFormCreatePayloadSerializer();
+    _$PinwheelDDFormCreatePayloadSerializer();
 Serializer<PinwheelScreenTransitionPayload>
     _$pinwheelScreenTransitionPayloadSerializer =
-    new _$PinwheelScreenTransitionPayloadSerializer();
+    _$PinwheelScreenTransitionPayloadSerializer();
+Serializer<PinwheelOtherEventPayloadValueType>
+    _$pinwheelOtherEventPayloadValueTypeSerializer =
+    _$PinwheelOtherEventPayloadValueTypeSerializer();
+Serializer<PinwheelOtherEventPayloadItem>
+    _$pinwheelOtherEventPayloadItemSerializer =
+    _$PinwheelOtherEventPayloadItemSerializer();
+Serializer<PinwheelOtherEventPayload> _$pinwheelOtherEventPayloadSerializer =
+    _$PinwheelOtherEventPayloadSerializer();
 
 class _$PinwheelAllocationSerializer
     implements StructuredSerializer<PinwheelAllocation> {
@@ -70,7 +107,7 @@ class _$PinwheelAllocationSerializer
   PinwheelAllocation deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelAllocationBuilder();
+    final result = PinwheelAllocationBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -130,7 +167,7 @@ class _$PinwheelInputAllocationPayloadSerializer
   PinwheelInputAllocationPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelInputAllocationPayloadBuilder();
+    final result = PinwheelInputAllocationPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -183,7 +220,7 @@ class _$PinwheelErrorSerializer implements StructuredSerializer<PinwheelError> {
   PinwheelError deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelErrorBuilder();
+    final result = PinwheelErrorBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -244,7 +281,7 @@ class _$PinwheelExitPayloadSerializer
   PinwheelExitPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelExitPayloadBuilder();
+    final result = PinwheelExitPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -297,7 +334,7 @@ class _$PinwheelLoginPayloadSerializer
   PinwheelLoginPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelLoginPayloadBuilder();
+    final result = PinwheelLoginPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -347,7 +384,7 @@ class _$PinwheelLoginAttemptPayloadSerializer
   PinwheelLoginAttemptPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelLoginAttemptPayloadBuilder();
+    final result = PinwheelLoginAttemptPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -399,7 +436,7 @@ class _$PinwheelParamsSerializer
   PinwheelParams deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelParamsBuilder();
+    final result = PinwheelParamsBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -453,7 +490,7 @@ class _$PinwheelSelectedEmployerPayloadSerializer
   PinwheelSelectedEmployerPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelSelectedEmployerPayloadBuilder();
+    final result = PinwheelSelectedEmployerPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -506,7 +543,7 @@ class _$PinwheelSelectedPlatformPayloadSerializer
   PinwheelSelectedPlatformPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelSelectedPlatformPayloadBuilder();
+    final result = PinwheelSelectedPlatformPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -564,7 +601,7 @@ class _$PinwheelSuccessPayloadSerializer
   PinwheelSuccessPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelSuccessPayloadBuilder();
+    final result = PinwheelSuccessPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -629,7 +666,7 @@ class _$PinwheelEventChannelArgumentSerializer
   PinwheelEventChannelArgument deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelEventChannelArgumentBuilder();
+    final result = PinwheelEventChannelArgumentBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -678,7 +715,7 @@ class _$PinwheelDDFormCreatePayloadSerializer
   PinwheelDDFormCreatePayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelDDFormCreatePayloadBuilder();
+    final result = PinwheelDDFormCreatePayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -752,7 +789,7 @@ class _$PinwheelScreenTransitionPayloadSerializer
   PinwheelScreenTransitionPayload deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = new PinwheelScreenTransitionPayloadBuilder();
+    final result = PinwheelScreenTransitionPayloadBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -787,6 +824,154 @@ class _$PinwheelScreenTransitionPayloadSerializer
   }
 }
 
+class _$PinwheelOtherEventPayloadValueTypeSerializer
+    implements PrimitiveSerializer<PinwheelOtherEventPayloadValueType> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'STRING': 'string',
+    'NUMBER': 'number',
+    'BOOLEAN': 'boolean',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'string': 'STRING',
+    'number': 'NUMBER',
+    'boolean': 'BOOLEAN',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[PinwheelOtherEventPayloadValueType];
+  @override
+  final String wireName = 'PinwheelOtherEventPayloadValueType';
+
+  @override
+  Object serialize(
+          Serializers serializers, PinwheelOtherEventPayloadValueType object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _toWire[object.name] ?? object.name;
+
+  @override
+  PinwheelOtherEventPayloadValueType deserialize(
+          Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      PinwheelOtherEventPayloadValueType.valueOf(
+          _fromWire[serialized] ?? (serialized is String ? serialized : ''));
+}
+
+class _$PinwheelOtherEventPayloadItemSerializer
+    implements StructuredSerializer<PinwheelOtherEventPayloadItem> {
+  @override
+  final Iterable<Type> types = const [
+    PinwheelOtherEventPayloadItem,
+    _$PinwheelOtherEventPayloadItem
+  ];
+  @override
+  final String wireName = 'PinwheelOtherEventPayloadItem';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, PinwheelOtherEventPayloadItem object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'key',
+      serializers.serialize(object.key, specifiedType: const FullType(String)),
+      'value',
+      serializers.serialize(object.value,
+          specifiedType: const FullType(String)),
+      'type',
+      serializers.serialize(object.type,
+          specifiedType: const FullType(PinwheelOtherEventPayloadValueType)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PinwheelOtherEventPayloadItem deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PinwheelOtherEventPayloadItemBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'key':
+          result.key = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'value':
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'type':
+          result.type = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(PinwheelOtherEventPayloadValueType))!
+              as PinwheelOtherEventPayloadValueType;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PinwheelOtherEventPayloadSerializer
+    implements StructuredSerializer<PinwheelOtherEventPayload> {
+  @override
+  final Iterable<Type> types = const [
+    PinwheelOtherEventPayload,
+    _$PinwheelOtherEventPayload
+  ];
+  @override
+  final String wireName = 'PinwheelOtherEventPayload';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, PinwheelOtherEventPayload object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'payload',
+      serializers.serialize(object.payload,
+          specifiedType: const FullType(BuiltList,
+              const [const FullType(PinwheelOtherEventPayloadItem)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  PinwheelOtherEventPayload deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PinwheelOtherEventPayloadBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'payload':
+          result.payload.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(PinwheelOtherEventPayloadItem)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 abstract class PinwheelEventPayloadBuilder {
   void replace(PinwheelEventPayload other);
   void update(void Function(PinwheelEventPayloadBuilder) updates);
@@ -800,12 +985,9 @@ class _$PinwheelAllocation extends PinwheelAllocation {
 
   factory _$PinwheelAllocation(
           [void Function(PinwheelAllocationBuilder)? updates]) =>
-      (new PinwheelAllocationBuilder()..update(updates))._build();
+      (PinwheelAllocationBuilder()..update(updates))._build();
 
-  _$PinwheelAllocation._({required this.type, this.value}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(type, r'PinwheelAllocation', 'type');
-  }
-
+  _$PinwheelAllocation._({required this.type, this.value}) : super._();
   @override
   PinwheelAllocation rebuild(
           void Function(PinwheelAllocationBuilder) updates) =>
@@ -813,7 +995,7 @@ class _$PinwheelAllocation extends PinwheelAllocation {
 
   @override
   PinwheelAllocationBuilder toBuilder() =>
-      new PinwheelAllocationBuilder()..replace(this);
+      PinwheelAllocationBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -869,7 +1051,6 @@ class PinwheelAllocationBuilder
 
   @override
   void replace(covariant PinwheelAllocation other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelAllocation;
   }
 
@@ -883,10 +1064,11 @@ class PinwheelAllocationBuilder
 
   _$PinwheelAllocation _build() {
     final _$result = _$v ??
-        new _$PinwheelAllocation._(
-            type: BuiltValueNullFieldError.checkNotNull(
-                type, r'PinwheelAllocation', 'type'),
-            value: value);
+        _$PinwheelAllocation._(
+          type: BuiltValueNullFieldError.checkNotNull(
+              type, r'PinwheelAllocation', 'type'),
+          value: value,
+        );
     replace(_$result);
     return _$result;
   }
@@ -900,11 +1082,10 @@ class _$PinwheelInputAllocationPayload extends PinwheelInputAllocationPayload {
 
   factory _$PinwheelInputAllocationPayload(
           [void Function(PinwheelInputAllocationPayloadBuilder)? updates]) =>
-      (new PinwheelInputAllocationPayloadBuilder()..update(updates))._build();
+      (PinwheelInputAllocationPayloadBuilder()..update(updates))._build();
 
   _$PinwheelInputAllocationPayload._({this.action, this.allocation})
       : super._();
-
   @override
   PinwheelInputAllocationPayload rebuild(
           void Function(PinwheelInputAllocationPayloadBuilder) updates) =>
@@ -912,7 +1093,7 @@ class _$PinwheelInputAllocationPayload extends PinwheelInputAllocationPayload {
 
   @override
   PinwheelInputAllocationPayloadBuilder toBuilder() =>
-      new PinwheelInputAllocationPayloadBuilder()..replace(this);
+      PinwheelInputAllocationPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -953,7 +1134,7 @@ class PinwheelInputAllocationPayloadBuilder
 
   PinwheelAllocationBuilder? _allocation;
   PinwheelAllocationBuilder get allocation =>
-      _$this._allocation ??= new PinwheelAllocationBuilder();
+      _$this._allocation ??= PinwheelAllocationBuilder();
   set allocation(covariant PinwheelAllocationBuilder? allocation) =>
       _$this._allocation = allocation;
 
@@ -971,7 +1152,6 @@ class PinwheelInputAllocationPayloadBuilder
 
   @override
   void replace(covariant PinwheelInputAllocationPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelInputAllocationPayload;
   }
 
@@ -987,15 +1167,17 @@ class PinwheelInputAllocationPayloadBuilder
     _$PinwheelInputAllocationPayload _$result;
     try {
       _$result = _$v ??
-          new _$PinwheelInputAllocationPayload._(
-              action: action, allocation: _allocation?.build());
+          _$PinwheelInputAllocationPayload._(
+            action: action,
+            allocation: _allocation?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'allocation';
         _allocation?.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
             r'PinwheelInputAllocationPayload', _$failedField, e.toString());
       }
       rethrow;
@@ -1016,27 +1198,20 @@ class _$PinwheelError extends PinwheelError {
   final bool pendingRetry;
 
   factory _$PinwheelError([void Function(PinwheelErrorBuilder)? updates]) =>
-      (new PinwheelErrorBuilder()..update(updates))._build();
+      (PinwheelErrorBuilder()..update(updates))._build();
 
   _$PinwheelError._(
       {required this.type,
       required this.code,
       required this.message,
       required this.pendingRetry})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(type, r'PinwheelError', 'type');
-    BuiltValueNullFieldError.checkNotNull(code, r'PinwheelError', 'code');
-    BuiltValueNullFieldError.checkNotNull(message, r'PinwheelError', 'message');
-    BuiltValueNullFieldError.checkNotNull(
-        pendingRetry, r'PinwheelError', 'pendingRetry');
-  }
-
+      : super._();
   @override
   PinwheelError rebuild(void Function(PinwheelErrorBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  PinwheelErrorBuilder toBuilder() => new PinwheelErrorBuilder()..replace(this);
+  PinwheelErrorBuilder toBuilder() => PinwheelErrorBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1109,7 +1284,6 @@ class PinwheelErrorBuilder
 
   @override
   void replace(covariant PinwheelError other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelError;
   }
 
@@ -1123,15 +1297,16 @@ class PinwheelErrorBuilder
 
   _$PinwheelError _build() {
     final _$result = _$v ??
-        new _$PinwheelError._(
-            type: BuiltValueNullFieldError.checkNotNull(
-                type, r'PinwheelError', 'type'),
-            code: BuiltValueNullFieldError.checkNotNull(
-                code, r'PinwheelError', 'code'),
-            message: BuiltValueNullFieldError.checkNotNull(
-                message, r'PinwheelError', 'message'),
-            pendingRetry: BuiltValueNullFieldError.checkNotNull(
-                pendingRetry, r'PinwheelError', 'pendingRetry'));
+        _$PinwheelError._(
+          type: BuiltValueNullFieldError.checkNotNull(
+              type, r'PinwheelError', 'type'),
+          code: BuiltValueNullFieldError.checkNotNull(
+              code, r'PinwheelError', 'code'),
+          message: BuiltValueNullFieldError.checkNotNull(
+              message, r'PinwheelError', 'message'),
+          pendingRetry: BuiltValueNullFieldError.checkNotNull(
+              pendingRetry, r'PinwheelError', 'pendingRetry'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1143,10 +1318,9 @@ class _$PinwheelExitPayload extends PinwheelExitPayload {
 
   factory _$PinwheelExitPayload(
           [void Function(PinwheelExitPayloadBuilder)? updates]) =>
-      (new PinwheelExitPayloadBuilder()..update(updates))._build();
+      (PinwheelExitPayloadBuilder()..update(updates))._build();
 
   _$PinwheelExitPayload._({this.error}) : super._();
-
   @override
   PinwheelExitPayload rebuild(
           void Function(PinwheelExitPayloadBuilder) updates) =>
@@ -1154,7 +1328,7 @@ class _$PinwheelExitPayload extends PinwheelExitPayload {
 
   @override
   PinwheelExitPayloadBuilder toBuilder() =>
-      new PinwheelExitPayloadBuilder()..replace(this);
+      PinwheelExitPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1185,8 +1359,7 @@ class PinwheelExitPayloadBuilder
   _$PinwheelExitPayload? _$v;
 
   PinwheelErrorBuilder? _error;
-  PinwheelErrorBuilder get error =>
-      _$this._error ??= new PinwheelErrorBuilder();
+  PinwheelErrorBuilder get error => _$this._error ??= PinwheelErrorBuilder();
   set error(covariant PinwheelErrorBuilder? error) => _$this._error = error;
 
   PinwheelExitPayloadBuilder();
@@ -1202,7 +1375,6 @@ class PinwheelExitPayloadBuilder
 
   @override
   void replace(covariant PinwheelExitPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelExitPayload;
   }
 
@@ -1217,14 +1389,17 @@ class PinwheelExitPayloadBuilder
   _$PinwheelExitPayload _build() {
     _$PinwheelExitPayload _$result;
     try {
-      _$result = _$v ?? new _$PinwheelExitPayload._(error: _error?.build());
+      _$result = _$v ??
+          _$PinwheelExitPayload._(
+            error: _error?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'error';
         _error?.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
             r'PinwheelExitPayload', _$failedField, e.toString());
       }
       rethrow;
@@ -1242,14 +1417,10 @@ class _$PinwheelLoginPayload extends PinwheelLoginPayload {
 
   factory _$PinwheelLoginPayload(
           [void Function(PinwheelLoginPayloadBuilder)? updates]) =>
-      (new PinwheelLoginPayloadBuilder()..update(updates))._build();
+      (PinwheelLoginPayloadBuilder()..update(updates))._build();
 
   _$PinwheelLoginPayload._({required this.accountId, this.platformId})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        accountId, r'PinwheelLoginPayload', 'accountId');
-  }
-
+      : super._();
   @override
   PinwheelLoginPayload rebuild(
           void Function(PinwheelLoginPayloadBuilder) updates) =>
@@ -1257,7 +1428,7 @@ class _$PinwheelLoginPayload extends PinwheelLoginPayload {
 
   @override
   PinwheelLoginPayloadBuilder toBuilder() =>
-      new PinwheelLoginPayloadBuilder()..replace(this);
+      PinwheelLoginPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1314,7 +1485,6 @@ class PinwheelLoginPayloadBuilder
 
   @override
   void replace(covariant PinwheelLoginPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelLoginPayload;
   }
 
@@ -1328,10 +1498,11 @@ class PinwheelLoginPayloadBuilder
 
   _$PinwheelLoginPayload _build() {
     final _$result = _$v ??
-        new _$PinwheelLoginPayload._(
-            accountId: BuiltValueNullFieldError.checkNotNull(
-                accountId, r'PinwheelLoginPayload', 'accountId'),
-            platformId: platformId);
+        _$PinwheelLoginPayload._(
+          accountId: BuiltValueNullFieldError.checkNotNull(
+              accountId, r'PinwheelLoginPayload', 'accountId'),
+          platformId: platformId,
+        );
     replace(_$result);
     return _$result;
   }
@@ -1343,13 +1514,9 @@ class _$PinwheelLoginAttemptPayload extends PinwheelLoginAttemptPayload {
 
   factory _$PinwheelLoginAttemptPayload(
           [void Function(PinwheelLoginAttemptPayloadBuilder)? updates]) =>
-      (new PinwheelLoginAttemptPayloadBuilder()..update(updates))._build();
+      (PinwheelLoginAttemptPayloadBuilder()..update(updates))._build();
 
-  _$PinwheelLoginAttemptPayload._({required this.platformId}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        platformId, r'PinwheelLoginAttemptPayload', 'platformId');
-  }
-
+  _$PinwheelLoginAttemptPayload._({required this.platformId}) : super._();
   @override
   PinwheelLoginAttemptPayload rebuild(
           void Function(PinwheelLoginAttemptPayloadBuilder) updates) =>
@@ -1357,7 +1524,7 @@ class _$PinwheelLoginAttemptPayload extends PinwheelLoginAttemptPayload {
 
   @override
   PinwheelLoginAttemptPayloadBuilder toBuilder() =>
-      new PinwheelLoginAttemptPayloadBuilder()..replace(this);
+      PinwheelLoginAttemptPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1407,7 +1574,6 @@ class PinwheelLoginAttemptPayloadBuilder
 
   @override
   void replace(covariant PinwheelLoginAttemptPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelLoginAttemptPayload;
   }
 
@@ -1421,9 +1587,10 @@ class PinwheelLoginAttemptPayloadBuilder
 
   _$PinwheelLoginAttemptPayload _build() {
     final _$result = _$v ??
-        new _$PinwheelLoginAttemptPayload._(
-            platformId: BuiltValueNullFieldError.checkNotNull(
-                platformId, r'PinwheelLoginAttemptPayload', 'platformId'));
+        _$PinwheelLoginAttemptPayload._(
+          platformId: BuiltValueNullFieldError.checkNotNull(
+              platformId, r'PinwheelLoginAttemptPayload', 'platformId'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1436,17 +1603,15 @@ class _$PinwheelParams extends PinwheelParams {
   final PinwheelAllocation? allocation;
 
   factory _$PinwheelParams([void Function(PinwheelParamsBuilder)? updates]) =>
-      (new PinwheelParamsBuilder()..update(updates))._build();
+      (PinwheelParamsBuilder()..update(updates))._build();
 
   _$PinwheelParams._({this.action, this.allocation}) : super._();
-
   @override
   PinwheelParams rebuild(void Function(PinwheelParamsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  PinwheelParamsBuilder toBuilder() =>
-      new PinwheelParamsBuilder()..replace(this);
+  PinwheelParamsBuilder toBuilder() => PinwheelParamsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1486,7 +1651,7 @@ class PinwheelParamsBuilder
 
   PinwheelAllocationBuilder? _allocation;
   PinwheelAllocationBuilder get allocation =>
-      _$this._allocation ??= new PinwheelAllocationBuilder();
+      _$this._allocation ??= PinwheelAllocationBuilder();
   set allocation(covariant PinwheelAllocationBuilder? allocation) =>
       _$this._allocation = allocation;
 
@@ -1504,7 +1669,6 @@ class PinwheelParamsBuilder
 
   @override
   void replace(covariant PinwheelParams other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelParams;
   }
 
@@ -1520,15 +1684,17 @@ class PinwheelParamsBuilder
     _$PinwheelParams _$result;
     try {
       _$result = _$v ??
-          new _$PinwheelParams._(
-              action: action, allocation: _allocation?.build());
+          _$PinwheelParams._(
+            action: action,
+            allocation: _allocation?.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'allocation';
         _allocation?.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
             r'PinwheelParams', _$failedField, e.toString());
       }
       rethrow;
@@ -1547,17 +1713,11 @@ class _$PinwheelSelectedEmployerPayload
 
   factory _$PinwheelSelectedEmployerPayload(
           [void Function(PinwheelSelectedEmployerPayloadBuilder)? updates]) =>
-      (new PinwheelSelectedEmployerPayloadBuilder()..update(updates))._build();
+      (PinwheelSelectedEmployerPayloadBuilder()..update(updates))._build();
 
   _$PinwheelSelectedEmployerPayload._(
       {required this.selectedEmployerId, required this.selectedEmployerName})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(selectedEmployerId,
-        r'PinwheelSelectedEmployerPayload', 'selectedEmployerId');
-    BuiltValueNullFieldError.checkNotNull(selectedEmployerName,
-        r'PinwheelSelectedEmployerPayload', 'selectedEmployerName');
-  }
-
+      : super._();
   @override
   PinwheelSelectedEmployerPayload rebuild(
           void Function(PinwheelSelectedEmployerPayloadBuilder) updates) =>
@@ -1565,7 +1725,7 @@ class _$PinwheelSelectedEmployerPayload
 
   @override
   PinwheelSelectedEmployerPayloadBuilder toBuilder() =>
-      new PinwheelSelectedEmployerPayloadBuilder()..replace(this);
+      PinwheelSelectedEmployerPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1624,7 +1784,6 @@ class PinwheelSelectedEmployerPayloadBuilder
 
   @override
   void replace(covariant PinwheelSelectedEmployerPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelSelectedEmployerPayload;
   }
 
@@ -1638,15 +1797,16 @@ class PinwheelSelectedEmployerPayloadBuilder
 
   _$PinwheelSelectedEmployerPayload _build() {
     final _$result = _$v ??
-        new _$PinwheelSelectedEmployerPayload._(
-            selectedEmployerId: BuiltValueNullFieldError.checkNotNull(
-                selectedEmployerId,
-                r'PinwheelSelectedEmployerPayload',
-                'selectedEmployerId'),
-            selectedEmployerName: BuiltValueNullFieldError.checkNotNull(
-                selectedEmployerName,
-                r'PinwheelSelectedEmployerPayload',
-                'selectedEmployerName'));
+        _$PinwheelSelectedEmployerPayload._(
+          selectedEmployerId: BuiltValueNullFieldError.checkNotNull(
+              selectedEmployerId,
+              r'PinwheelSelectedEmployerPayload',
+              'selectedEmployerId'),
+          selectedEmployerName: BuiltValueNullFieldError.checkNotNull(
+              selectedEmployerName,
+              r'PinwheelSelectedEmployerPayload',
+              'selectedEmployerName'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1661,17 +1821,11 @@ class _$PinwheelSelectedPlatformPayload
 
   factory _$PinwheelSelectedPlatformPayload(
           [void Function(PinwheelSelectedPlatformPayloadBuilder)? updates]) =>
-      (new PinwheelSelectedPlatformPayloadBuilder()..update(updates))._build();
+      (PinwheelSelectedPlatformPayloadBuilder()..update(updates))._build();
 
   _$PinwheelSelectedPlatformPayload._(
       {required this.selectedPlatformId, required this.selectedPlatformName})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(selectedPlatformId,
-        r'PinwheelSelectedPlatformPayload', 'selectedPlatformId');
-    BuiltValueNullFieldError.checkNotNull(selectedPlatformName,
-        r'PinwheelSelectedPlatformPayload', 'selectedPlatformName');
-  }
-
+      : super._();
   @override
   PinwheelSelectedPlatformPayload rebuild(
           void Function(PinwheelSelectedPlatformPayloadBuilder) updates) =>
@@ -1679,7 +1833,7 @@ class _$PinwheelSelectedPlatformPayload
 
   @override
   PinwheelSelectedPlatformPayloadBuilder toBuilder() =>
-      new PinwheelSelectedPlatformPayloadBuilder()..replace(this);
+      PinwheelSelectedPlatformPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1738,7 +1892,6 @@ class PinwheelSelectedPlatformPayloadBuilder
 
   @override
   void replace(covariant PinwheelSelectedPlatformPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelSelectedPlatformPayload;
   }
 
@@ -1752,15 +1905,16 @@ class PinwheelSelectedPlatformPayloadBuilder
 
   _$PinwheelSelectedPlatformPayload _build() {
     final _$result = _$v ??
-        new _$PinwheelSelectedPlatformPayload._(
-            selectedPlatformId: BuiltValueNullFieldError.checkNotNull(
-                selectedPlatformId,
-                r'PinwheelSelectedPlatformPayload',
-                'selectedPlatformId'),
-            selectedPlatformName: BuiltValueNullFieldError.checkNotNull(
-                selectedPlatformName,
-                r'PinwheelSelectedPlatformPayload',
-                'selectedPlatformName'));
+        _$PinwheelSelectedPlatformPayload._(
+          selectedPlatformId: BuiltValueNullFieldError.checkNotNull(
+              selectedPlatformId,
+              r'PinwheelSelectedPlatformPayload',
+              'selectedPlatformId'),
+          selectedPlatformName: BuiltValueNullFieldError.checkNotNull(
+              selectedPlatformName,
+              r'PinwheelSelectedPlatformPayload',
+              'selectedPlatformName'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -1778,24 +1932,14 @@ class _$PinwheelSuccessPayload extends PinwheelSuccessPayload {
 
   factory _$PinwheelSuccessPayload(
           [void Function(PinwheelSuccessPayloadBuilder)? updates]) =>
-      (new PinwheelSuccessPayloadBuilder()..update(updates))._build();
+      (PinwheelSuccessPayloadBuilder()..update(updates))._build();
 
   _$PinwheelSuccessPayload._(
       {required this.accountId,
       required this.platformId,
       required this.job,
       required this.params})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        accountId, r'PinwheelSuccessPayload', 'accountId');
-    BuiltValueNullFieldError.checkNotNull(
-        platformId, r'PinwheelSuccessPayload', 'platformId');
-    BuiltValueNullFieldError.checkNotNull(
-        job, r'PinwheelSuccessPayload', 'job');
-    BuiltValueNullFieldError.checkNotNull(
-        params, r'PinwheelSuccessPayload', 'params');
-  }
-
+      : super._();
   @override
   PinwheelSuccessPayload rebuild(
           void Function(PinwheelSuccessPayloadBuilder) updates) =>
@@ -1803,7 +1947,7 @@ class _$PinwheelSuccessPayload extends PinwheelSuccessPayload {
 
   @override
   PinwheelSuccessPayloadBuilder toBuilder() =>
-      new PinwheelSuccessPayloadBuilder()..replace(this);
+      PinwheelSuccessPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1858,7 +2002,7 @@ class PinwheelSuccessPayloadBuilder
 
   PinwheelParamsBuilder? _params;
   PinwheelParamsBuilder get params =>
-      _$this._params ??= new PinwheelParamsBuilder();
+      _$this._params ??= PinwheelParamsBuilder();
   set params(covariant PinwheelParamsBuilder? params) =>
       _$this._params = params;
 
@@ -1878,7 +2022,6 @@ class PinwheelSuccessPayloadBuilder
 
   @override
   void replace(covariant PinwheelSuccessPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelSuccessPayload;
   }
 
@@ -1894,21 +2037,22 @@ class PinwheelSuccessPayloadBuilder
     _$PinwheelSuccessPayload _$result;
     try {
       _$result = _$v ??
-          new _$PinwheelSuccessPayload._(
-              accountId: BuiltValueNullFieldError.checkNotNull(
-                  accountId, r'PinwheelSuccessPayload', 'accountId'),
-              platformId: BuiltValueNullFieldError.checkNotNull(
-                  platformId, r'PinwheelSuccessPayload', 'platformId'),
-              job: BuiltValueNullFieldError.checkNotNull(
-                  job, r'PinwheelSuccessPayload', 'job'),
-              params: params.build());
+          _$PinwheelSuccessPayload._(
+            accountId: BuiltValueNullFieldError.checkNotNull(
+                accountId, r'PinwheelSuccessPayload', 'accountId'),
+            platformId: BuiltValueNullFieldError.checkNotNull(
+                platformId, r'PinwheelSuccessPayload', 'platformId'),
+            job: BuiltValueNullFieldError.checkNotNull(
+                job, r'PinwheelSuccessPayload', 'job'),
+            params: params.build(),
+          );
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'params';
         params.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
             r'PinwheelSuccessPayload', _$failedField, e.toString());
       }
       rethrow;
@@ -1926,14 +2070,10 @@ class _$PinwheelEventChannelArgument extends PinwheelEventChannelArgument {
 
   factory _$PinwheelEventChannelArgument(
           [void Function(PinwheelEventChannelArgumentBuilder)? updates]) =>
-      (new PinwheelEventChannelArgumentBuilder()..update(updates))._build();
+      (PinwheelEventChannelArgumentBuilder()..update(updates))._build();
 
   _$PinwheelEventChannelArgument._({required this.name, this.payload})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        name, r'PinwheelEventChannelArgument', 'name');
-  }
-
+      : super._();
   @override
   PinwheelEventChannelArgument rebuild(
           void Function(PinwheelEventChannelArgumentBuilder) updates) =>
@@ -1941,7 +2081,7 @@ class _$PinwheelEventChannelArgument extends PinwheelEventChannelArgument {
 
   @override
   PinwheelEventChannelArgumentBuilder toBuilder() =>
-      new PinwheelEventChannelArgumentBuilder()..replace(this);
+      PinwheelEventChannelArgumentBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1997,7 +2137,6 @@ class PinwheelEventChannelArgumentBuilder
 
   @override
   void replace(PinwheelEventChannelArgument other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelEventChannelArgument;
   }
 
@@ -2011,10 +2150,11 @@ class PinwheelEventChannelArgumentBuilder
 
   _$PinwheelEventChannelArgument _build() {
     final _$result = _$v ??
-        new _$PinwheelEventChannelArgument._(
-            name: BuiltValueNullFieldError.checkNotNull(
-                name, r'PinwheelEventChannelArgument', 'name'),
-            payload: payload);
+        _$PinwheelEventChannelArgument._(
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'PinwheelEventChannelArgument', 'name'),
+          payload: payload,
+        );
     replace(_$result);
     return _$result;
   }
@@ -2026,13 +2166,9 @@ class _$PinwheelDDFormCreatePayload extends PinwheelDDFormCreatePayload {
 
   factory _$PinwheelDDFormCreatePayload(
           [void Function(PinwheelDDFormCreatePayloadBuilder)? updates]) =>
-      (new PinwheelDDFormCreatePayloadBuilder()..update(updates))._build();
+      (PinwheelDDFormCreatePayloadBuilder()..update(updates))._build();
 
-  _$PinwheelDDFormCreatePayload._({required this.url}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        url, r'PinwheelDDFormCreatePayload', 'url');
-  }
-
+  _$PinwheelDDFormCreatePayload._({required this.url}) : super._();
   @override
   PinwheelDDFormCreatePayload rebuild(
           void Function(PinwheelDDFormCreatePayloadBuilder) updates) =>
@@ -2040,7 +2176,7 @@ class _$PinwheelDDFormCreatePayload extends PinwheelDDFormCreatePayload {
 
   @override
   PinwheelDDFormCreatePayloadBuilder toBuilder() =>
-      new PinwheelDDFormCreatePayloadBuilder()..replace(this);
+      PinwheelDDFormCreatePayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -2088,7 +2224,6 @@ class PinwheelDDFormCreatePayloadBuilder
 
   @override
   void replace(covariant PinwheelDDFormCreatePayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelDDFormCreatePayload;
   }
 
@@ -2102,9 +2237,10 @@ class PinwheelDDFormCreatePayloadBuilder
 
   _$PinwheelDDFormCreatePayload _build() {
     final _$result = _$v ??
-        new _$PinwheelDDFormCreatePayload._(
-            url: BuiltValueNullFieldError.checkNotNull(
-                url, r'PinwheelDDFormCreatePayload', 'url'));
+        _$PinwheelDDFormCreatePayload._(
+          url: BuiltValueNullFieldError.checkNotNull(
+              url, r'PinwheelDDFormCreatePayload', 'url'),
+        );
     replace(_$result);
     return _$result;
   }
@@ -2125,7 +2261,7 @@ class _$PinwheelScreenTransitionPayload
 
   factory _$PinwheelScreenTransitionPayload(
           [void Function(PinwheelScreenTransitionPayloadBuilder)? updates]) =>
-      (new PinwheelScreenTransitionPayloadBuilder()..update(updates))._build();
+      (PinwheelScreenTransitionPayloadBuilder()..update(updates))._build();
 
   _$PinwheelScreenTransitionPayload._(
       {required this.screenName,
@@ -2133,11 +2269,7 @@ class _$PinwheelScreenTransitionPayload
       this.selectedEmployerName,
       this.selectedPlatformId,
       this.selectedPlatformName})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        screenName, r'PinwheelScreenTransitionPayload', 'screenName');
-  }
-
+      : super._();
   @override
   PinwheelScreenTransitionPayload rebuild(
           void Function(PinwheelScreenTransitionPayloadBuilder) updates) =>
@@ -2145,7 +2277,7 @@ class _$PinwheelScreenTransitionPayload
 
   @override
   PinwheelScreenTransitionPayloadBuilder toBuilder() =>
-      new PinwheelScreenTransitionPayloadBuilder()..replace(this);
+      PinwheelScreenTransitionPayloadBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -2231,7 +2363,6 @@ class PinwheelScreenTransitionPayloadBuilder
 
   @override
   void replace(covariant PinwheelScreenTransitionPayload other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PinwheelScreenTransitionPayload;
   }
 
@@ -2245,13 +2376,239 @@ class PinwheelScreenTransitionPayloadBuilder
 
   _$PinwheelScreenTransitionPayload _build() {
     final _$result = _$v ??
-        new _$PinwheelScreenTransitionPayload._(
-            screenName: BuiltValueNullFieldError.checkNotNull(
-                screenName, r'PinwheelScreenTransitionPayload', 'screenName'),
-            selectedEmployerId: selectedEmployerId,
-            selectedEmployerName: selectedEmployerName,
-            selectedPlatformId: selectedPlatformId,
-            selectedPlatformName: selectedPlatformName);
+        _$PinwheelScreenTransitionPayload._(
+          screenName: BuiltValueNullFieldError.checkNotNull(
+              screenName, r'PinwheelScreenTransitionPayload', 'screenName'),
+          selectedEmployerId: selectedEmployerId,
+          selectedEmployerName: selectedEmployerName,
+          selectedPlatformId: selectedPlatformId,
+          selectedPlatformName: selectedPlatformName,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PinwheelOtherEventPayloadItem extends PinwheelOtherEventPayloadItem {
+  @override
+  final String key;
+  @override
+  final String value;
+  @override
+  final PinwheelOtherEventPayloadValueType type;
+
+  factory _$PinwheelOtherEventPayloadItem(
+          [void Function(PinwheelOtherEventPayloadItemBuilder)? updates]) =>
+      (PinwheelOtherEventPayloadItemBuilder()..update(updates))._build();
+
+  _$PinwheelOtherEventPayloadItem._(
+      {required this.key, required this.value, required this.type})
+      : super._();
+  @override
+  PinwheelOtherEventPayloadItem rebuild(
+          void Function(PinwheelOtherEventPayloadItemBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PinwheelOtherEventPayloadItemBuilder toBuilder() =>
+      PinwheelOtherEventPayloadItemBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PinwheelOtherEventPayloadItem &&
+        key == other.key &&
+        value == other.value &&
+        type == other.type;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, key.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PinwheelOtherEventPayloadItem')
+          ..add('key', key)
+          ..add('value', value)
+          ..add('type', type))
+        .toString();
+  }
+}
+
+class PinwheelOtherEventPayloadItemBuilder
+    implements
+        Builder<PinwheelOtherEventPayloadItem,
+            PinwheelOtherEventPayloadItemBuilder> {
+  _$PinwheelOtherEventPayloadItem? _$v;
+
+  String? _key;
+  String? get key => _$this._key;
+  set key(String? key) => _$this._key = key;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(String? value) => _$this._value = value;
+
+  PinwheelOtherEventPayloadValueType? _type;
+  PinwheelOtherEventPayloadValueType? get type => _$this._type;
+  set type(PinwheelOtherEventPayloadValueType? type) => _$this._type = type;
+
+  PinwheelOtherEventPayloadItemBuilder();
+
+  PinwheelOtherEventPayloadItemBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _key = $v.key;
+      _value = $v.value;
+      _type = $v.type;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PinwheelOtherEventPayloadItem other) {
+    _$v = other as _$PinwheelOtherEventPayloadItem;
+  }
+
+  @override
+  void update(void Function(PinwheelOtherEventPayloadItemBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PinwheelOtherEventPayloadItem build() => _build();
+
+  _$PinwheelOtherEventPayloadItem _build() {
+    final _$result = _$v ??
+        _$PinwheelOtherEventPayloadItem._(
+          key: BuiltValueNullFieldError.checkNotNull(
+              key, r'PinwheelOtherEventPayloadItem', 'key'),
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'PinwheelOtherEventPayloadItem', 'value'),
+          type: BuiltValueNullFieldError.checkNotNull(
+              type, r'PinwheelOtherEventPayloadItem', 'type'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PinwheelOtherEventPayload extends PinwheelOtherEventPayload {
+  @override
+  final String name;
+  @override
+  final BuiltList<PinwheelOtherEventPayloadItem> payload;
+
+  factory _$PinwheelOtherEventPayload(
+          [void Function(PinwheelOtherEventPayloadBuilder)? updates]) =>
+      (PinwheelOtherEventPayloadBuilder()..update(updates))._build();
+
+  _$PinwheelOtherEventPayload._({required this.name, required this.payload})
+      : super._();
+  @override
+  PinwheelOtherEventPayload rebuild(
+          void Function(PinwheelOtherEventPayloadBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PinwheelOtherEventPayloadBuilder toBuilder() =>
+      PinwheelOtherEventPayloadBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PinwheelOtherEventPayload &&
+        name == other.name &&
+        payload == other.payload;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, payload.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PinwheelOtherEventPayload')
+          ..add('name', name)
+          ..add('payload', payload))
+        .toString();
+  }
+}
+
+class PinwheelOtherEventPayloadBuilder
+    implements
+        Builder<PinwheelOtherEventPayload, PinwheelOtherEventPayloadBuilder>,
+        PinwheelEventPayloadBuilder {
+  _$PinwheelOtherEventPayload? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  ListBuilder<PinwheelOtherEventPayloadItem>? _payload;
+  ListBuilder<PinwheelOtherEventPayloadItem> get payload =>
+      _$this._payload ??= ListBuilder<PinwheelOtherEventPayloadItem>();
+  set payload(covariant ListBuilder<PinwheelOtherEventPayloadItem>? payload) =>
+      _$this._payload = payload;
+
+  PinwheelOtherEventPayloadBuilder();
+
+  PinwheelOtherEventPayloadBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _payload = $v.payload.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PinwheelOtherEventPayload other) {
+    _$v = other as _$PinwheelOtherEventPayload;
+  }
+
+  @override
+  void update(void Function(PinwheelOtherEventPayloadBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PinwheelOtherEventPayload build() => _build();
+
+  _$PinwheelOtherEventPayload _build() {
+    _$PinwheelOtherEventPayload _$result;
+    try {
+      _$result = _$v ??
+          _$PinwheelOtherEventPayload._(
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, r'PinwheelOtherEventPayload', 'name'),
+            payload: payload.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'payload';
+        payload.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'PinwheelOtherEventPayload', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }

--- a/lib/pinwheel.dart
+++ b/lib/pinwheel.dart
@@ -10,16 +10,18 @@ import 'package:flutter/rendering.dart';
 
 typedef PinwheelExitCallback = void Function(PinwheelExitPayload? payload);
 typedef PinwheelErrorCallback = void Function(PinwheelError error);
-typedef PinwheelEventCallback = void Function(String name, PinwheelEventPayload? payload);
+typedef PinwheelEventCallback = void Function(
+    String name, PinwheelEventPayload? payload);
 typedef PinwheelSuccessCallback = void Function(PinwheelSuccessPayload payload);
 typedef PinwheelLoginCallback = void Function(PinwheelLoginPayload payload);
-typedef PinwheelLoginAttemptCallback = void Function(PinwheelLoginAttemptPayload payload);
+typedef PinwheelLoginAttemptCallback = void Function(
+    PinwheelLoginAttemptPayload payload);
 
 class Pinwheel {
   static const MethodChannel _channel =
       const MethodChannel('pinwheel', JSONMethodCodec());
 
-    static final _standardSerializers =
+  static final _standardSerializers =
       (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
 
   PinwheelErrorCallback? _onError;
@@ -30,15 +32,13 @@ class Pinwheel {
   PinwheelLoginAttemptCallback? _onLoginAttempt;
 
   Pinwheel(
-    int id,
-    PinwheelErrorCallback? onError,
-    PinwheelExitCallback? onExit,
-    PinwheelEventCallback? onEvent,
-    PinwheelSuccessCallback? onSuccess,
-    PinwheelLoginCallback? onLogin,
-    PinwheelLoginAttemptCallback? onLoginAttempt
-  ) {
-
+      int id,
+      PinwheelErrorCallback? onError,
+      PinwheelExitCallback? onExit,
+      PinwheelEventCallback? onEvent,
+      PinwheelSuccessCallback? onSuccess,
+      PinwheelLoginCallback? onLogin,
+      PinwheelLoginAttemptCallback? onLoginAttempt) {
     _channel.setMethodCallHandler(_handleMethod);
     _onError = onError;
     _onExit = onExit;
@@ -56,48 +56,68 @@ class Pinwheel {
           PinwheelEventPayload? payload;
           if (call.arguments != null && call.arguments != "null") {
             var data = _standardSerializers.deserializeWith(
-                PinwheelEventChannelArgument.serializer, json.decode(call.arguments))!;
+                PinwheelEventChannelArgument.serializer,
+                json.decode(call.arguments))!;
             name = data.name;
             if (data.payload != null) {
               String payloadString = data.payload!;
               switch (name) {
                 case 'select_employer':
-                  payload = _standardSerializers.deserializeWith(PinwheelSelectedEmployerPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelSelectedEmployerPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'select_platform':
-                  payload = _standardSerializers.deserializeWith(PinwheelSelectedPlatformPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelSelectedPlatformPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'login':
-                  payload = _standardSerializers.deserializeWith(PinwheelLoginPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelLoginPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'login_attempt':
-                  payload = _standardSerializers.deserializeWith(PinwheelLoginAttemptPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelLoginAttemptPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'input_allocation':
-                  payload = _standardSerializers.deserializeWith(PinwheelInputAllocationPayload.serializer, json.decode(payloadString));
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelInputAllocationPayload.serializer,
+                      json.decode(payloadString));
                   break;
                 case 'exit':
-                  payload = _standardSerializers.deserializeWith(PinwheelSelectedEmployerPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelSelectedEmployerPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'success':
-                  payload = _standardSerializers.deserializeWith(PinwheelSuccessPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelSuccessPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'error':
-                  payload = _standardSerializers.deserializeWith(PinwheelError.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelError.serializer, json.decode(payloadString))!;
                   break;
                 case 'dd_form_create':
-                  payload = _standardSerializers.deserializeWith(PinwheelDDFormCreatePayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelDDFormCreatePayload.serializer,
+                      json.decode(payloadString))!;
                   break;
                 case 'screen_transition':
-                  payload = _standardSerializers.deserializeWith(PinwheelScreenTransitionPayload.serializer, json.decode(payloadString))!;
+                  payload = _standardSerializers.deserializeWith(
+                      PinwheelScreenTransitionPayload.serializer,
+                      json.decode(payloadString))!;
                   break;
               }
             }
             if (_onEvent != null) {
               _onEvent!(name, payload);
-            }  
+            }
           }
-        } catch(error) {
+        } catch (error) {
           print(error);
         }
         break;
@@ -106,52 +126,56 @@ class Pinwheel {
         try {
           PinwheelExitPayload? result;
           if (call.arguments != null && call.arguments != "null") {
-            result = _standardSerializers.deserializeWith(PinwheelExitPayload.serializer, json.decode(call.arguments))!;
+            result = _standardSerializers.deserializeWith(
+                PinwheelExitPayload.serializer, json.decode(call.arguments))!;
           }
           if (_onExit != null) {
             _onExit!(result);
           }
-          
-        } catch(error) {
+        } catch (error) {
           print(error);
         }
         break;
       case 'onError':
         try {
-          var result = _standardSerializers.deserializeWith(PinwheelError.serializer, json.decode(call.arguments))!;
+          var result = _standardSerializers.deserializeWith(
+              PinwheelError.serializer, json.decode(call.arguments))!;
           if (_onError != null) {
             _onError!(result);
           }
-        } catch(error) {
-        }
+        } catch (error) {}
         break;
       case 'onSuccess':
         try {
-          var result = _standardSerializers.deserializeWith(PinwheelSuccessPayload.serializer, json.decode(call.arguments))!;
+          var result = _standardSerializers.deserializeWith(
+              PinwheelSuccessPayload.serializer, json.decode(call.arguments))!;
           if (_onSuccess != null) {
             _onSuccess!(result);
           }
-        } catch(error) {
+        } catch (error) {
           print(error);
         }
         break;
       case 'onLogin':
         try {
-          var result = _standardSerializers.deserializeWith(PinwheelLoginPayload.serializer, json.decode(call.arguments))!;
+          var result = _standardSerializers.deserializeWith(
+              PinwheelLoginPayload.serializer, json.decode(call.arguments))!;
           if (_onLogin != null) {
             _onLogin!(result);
           }
-        } catch(error) {
+        } catch (error) {
           print(error);
         }
         break;
       case 'onLoginAttempt':
         try {
-          var result = _standardSerializers.deserializeWith(PinwheelLoginAttemptPayload.serializer, json.decode(call.arguments))!;
+          var result = _standardSerializers.deserializeWith(
+              PinwheelLoginAttemptPayload.serializer,
+              json.decode(call.arguments))!;
           if (_onLoginAttempt != null) {
             _onLoginAttempt!(result);
           }
-        } catch(error) {
+        } catch (error) {
           print(error);
         }
         break;
@@ -167,17 +191,19 @@ class PinwheelLink extends StatefulWidget {
   final PinwheelSuccessCallback? onSuccess;
   final PinwheelLoginCallback? onLogin;
   final PinwheelLoginAttemptCallback? onLoginAttempt;
+  final bool? useDarkMode;
 
-  const PinwheelLink ({ 
-    Key? key, 
-    required this.token,
-    this.onExit,
-    this.onError,
-    this.onEvent,
-    this.onSuccess,
-    this.onLogin,
-    this.onLoginAttempt
-  }): super(key: key);
+  const PinwheelLink(
+      {Key? key,
+      required this.token,
+      this.onExit,
+      this.onError,
+      this.onEvent,
+      this.onSuccess,
+      this.onLogin,
+      this.onLoginAttempt,
+      this.useDarkMode})
+      : super(key: key);
 
   @override
   PinwheelLinkState createState() => PinwheelLinkState();
@@ -188,19 +214,21 @@ class PinwheelLinkState extends State<PinwheelLink> {
 
   Widget build(BuildContext context) {
     final String viewType = 'pinwheel-link-view';
-    final Map<String, String> creationParams = {
-      "token": widget.token
+    final Map<String, dynamic> creationParams = {
+      "token": widget.token,
+      "useDarkMode": widget.useDarkMode,
     };
-    
+
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         return PlatformViewLink(
           viewType: viewType,
-          surfaceFactory: (BuildContext context, PlatformViewController controller) {
-
+          surfaceFactory:
+              (BuildContext context, PlatformViewController controller) {
             return AndroidViewSurface(
               controller: controller as AndroidViewController,
-              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+              gestureRecognizers: const <Factory<
+                  OneSequenceGestureRecognizer>>{},
               hitTestBehavior: PlatformViewHitTestBehavior.opaque,
             );
           },
@@ -212,11 +240,11 @@ class PinwheelLinkState extends State<PinwheelLink> {
               creationParams: creationParams,
               creationParamsCodec: JSONMessageCodec(),
             )
-            ..addOnPlatformViewCreatedListener((int id) {
-              params.onPlatformViewCreated(id);
-              _onPlatformViewCreated(id);
-            })
-            ..create();
+              ..addOnPlatformViewCreatedListener((int id) {
+                params.onPlatformViewCreated(id);
+                _onPlatformViewCreated(id);
+              })
+              ..create();
           },
         );
       case TargetPlatform.iOS:

--- a/lib/serializers.g.dart
+++ b/lib/serializers.g.dart
@@ -6,7 +6,7 @@ part of 'serializers.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializers _$serializers = (new Serializers().toBuilder()
+Serializers _$serializers = (Serializers().toBuilder()
       ..add(PinwheelAllocation.serializer)
       ..add(PinwheelDDFormCreatePayload.serializer)
       ..add(PinwheelError.serializer)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,90 +5,90 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
+      sha256: f0bb5d1648339c8308cc0b9838d8456b3cfe5c91f9dc1a735b4d003269e5da9a
       url: "https://pub.dev"
     source: hosted
-    version: "64.0.0"
+    version: "88.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
+      sha256: "0b7b9c329d2879f8f05d6c05b32ee9ec025f39b077864bdb5ac9a7b63418a98f"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "8.1.1"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: "6439a9c71a4e6eca8d9490c1b380a25b02675aa688137dfbe66d2062884a23ac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "3.0.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: "2b21a125d66a86b9511cc3fb6c668c42e9a1185083922bf60e46d483a81a9712"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
+      sha256: fd3c09f4bbff7fa6e8d8ef688a0b2e8a6384e6483a25af0dac75fef362bcfe6f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.8"
+    version: "2.7.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
+      sha256: ab27e46c8aa233e610cf6084ee6d8a22c6f873a0a9929241d8855b7a72978ae7
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "9.3.0"
   built_collection:
     dependency: transitive
     description:
@@ -101,106 +101,106 @@ packages:
     dependency: "direct main"
     description:
       name: built_value
-      sha256: a3ec2e0f967bc47f69f95009bb93db936288d61d5343b9436e378b28a2f830c6
+      sha256: ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.0"
+    version: "8.11.1"
   built_value_generator:
     dependency: "direct dev"
     description:
       name: built_value_generator
-      sha256: dc1ad016357f56e596ddf026b72f90040be8c0076365cec79fc1c825869bed57
+      sha256: "82281895e5347dd70ffd3aab2756f39d52b55c945fa0efa635ad6d643dae5833"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.0"
+    version: "8.11.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
+      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "3.1.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -215,122 +215,138 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
+    version: "1.0.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.1"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
@@ -343,159 +359,175 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.5.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "3.1.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.3"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.3"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.8.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## Description of the change

Pulls in our latest iOS and Android SDKs, and updates the build/configs to support that. Also updates all client event interfaces/implementations to properly support the latest events. Adds support for passing in `useDarkMode`.

Note -- no version bump here so this won't publish an SDK update (that'll come in a subsequent PR, along with support for auxiliary functionality like `useDarkMode`).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 